### PR TITLE
extend Wrap() to intuitively support multiple errors

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+    "sonarlint.connectedMode.project": {
+        "connectionId": "SonarCloud (blugnu)",
+        "projectKey": "blugnu:errorcontext"
+    }
+}

--- a/.vscode/spellright.dict
+++ b/.vscode/spellright.dict
@@ -1,4 +1,0 @@
-blugnu
-errorcontext
-errorf
-golang

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <div align="center" style="margin-bottom:20px">
   <img src=".assets/banner.png" alt="errorcontext" />
   <div align="center">
-    <a href="https://github.com/blugnu/errorcontext/actions/workflows/qa.yml"><img alt="build-status" src="https://github.com/blugnu/errorcontext/actions/workflows/qa.yml/badge.svg?branch=master&style=flat-square"/></a>
+    <a href="https://github.com/blugnu/errorcontext/actions/workflows/pipeline.yml"><img alt="build-status" src="https://github.com/blugnu/errorcontext/actions/workflows/pipeline.yml/badge.svg"/></a>
     <a href="https://goreportcard.com/report/github.com/blugnu/errorcontext" ><img alt="go report" src="https://goreportcard.com/badge/github.com/blugnu/errorcontext"/></a>
     <a><img alt="go version >= 1.14" src="https://img.shields.io/github/go-mod/go-version/blugnu/errorcontext?style=flat-square"/></a>
     <a href="https://github.com/blugnu/errorcontext/blob/master/LICENSE"><img alt="MIT License" src="https://img.shields.io/github/license/blugnu/errorcontext?color=%234275f5&style=flat-square"/></a>
@@ -10,15 +10,14 @@
   </div>
 </div>
 
-<br/>
-
-# blugnu/errorcontext
 
 > **TL;DR**: to get started, `go get github.com/blugnu/errorcontext@v0.2.0` (or later, if available)
 
-> **NOTE:** _this module was one of the first that I developed and I made some mistakes when initially publishing it.  This has resulted in problems with version `v0.1.0` already cached in the golang ecosystem.  The first useable version of this module therefore is `v0.2.0`._
+> **NOTE:** _the original incarnation of this module was one of the first that I released publicly and I made some mistakes_. _This resulted in problems with version `v0.1.0` already cached in the golang ecosystem.  The first useable version of this module is therefore `v0.2.0`.<br/>:blush:_
 
-A `go` package providing an `error` implementation that wraps an `error` together with a supplied `Context`.  A number of factory functions are provided to create/wrap contextual errors in a variety of circumstances:
+A `go` package providing an `error` implementation that wraps an `error` together with a supplied `Context`.
+
+A number of factory functions are provided to create/wrap contextual errors in a variety of circumstances:
 
 | function | description |
 | -- | -- |

--- a/README.md
+++ b/README.md
@@ -10,12 +10,20 @@
   </div>
 </div>
 
+# blugnu/errorcontext
 
-> **TL;DR**: to get started, `go get github.com/blugnu/errorcontext@v0.2.0` (or later, if available)
-
-> **NOTE:** _the original incarnation of this module was one of the first that I released publicly and I made some mistakes_. _This resulted in problems with version `v0.1.0` already cached in the golang ecosystem.  The first useable version of this module is therefore `v0.2.0`.<br/>:blush:_
+> **TL;DR**: to get started, `go get github.com/blugnu/errorcontext` (or later, if available)
 
 A `go` package providing an `error` implementation that wraps an `error` together with a supplied `Context`.
+
+## History
+
+This module is a ground-up re-write of the previously released (and still available) `go-errorcontext` module.  This new implementation incorporate a number of improvements and simplifies the API.
+
+It has been renamed as `errorcontext` rather than being a v2 release of the original as the opportunity has also been taken to remove the superfluous and cumbersome `go-` prefix from the module name.
+
+
+## Creating Errors
 
 A number of factory functions are provided to create/wrap contextual errors in a variety of circumstances:
 
@@ -23,11 +31,9 @@ A number of factory functions are provided to create/wrap contextual errors in a
 | -- | -- |
 | `New(ctx, s)` | creates a new error using `errors.New()` given a string |
 | `Errorf(ctx, format, args...)` | creates a new error using `fmt.Errorf()` given a format string and args |
-| `Wrap(ctx, err)` | creates an error that wraps an existing error |
+| `Wrap(ctx, err)` | creates an error wrapping an existing error together with a specified `Context` |
 
-All functions require a `Context`, to be associated with the `error`.
-
-## Creating Errors
+All functions require a `Context`.
 
 ### _example: New()_
 ```golang

--- a/errorWithContext.go
+++ b/errorWithContext.go
@@ -13,20 +13,53 @@ type ErrorWithContext struct {
 
 // Error implements the error interface.
 func (err ErrorWithContext) Error() string {
-	return err.error.Error()
+	if err.error != nil {
+		return err.error.Error()
+	}
+	return "unknown error"
 }
 
-// Context returns the innermost context accessible from
+// Context returns the inner-most context accessible from
 // this error or any wrapped ErrorWithContext.
+//
+// That is, the wrapped error is tested to determine if it
+// is (or wraps) an ErrorWithContext and if it is the Context()
+// function on that wrapped error is called.  This continues
+// recursively until there are no more ErrorWithContext errors
+// to be unwrapped.
 func (err ErrorWithContext) Context() context.Context {
-	inner := &ErrorWithContext{}
-	if errors.As(err.error, &inner) {
-		return inner.Context()
+	wrapped := ErrorWithContext{}
+	if errors.As(err.error, &wrapped) {
+		return wrapped.Context()
 	}
 	return err.ctx
 }
 
-// Unwrap implements unwrapping to return the wrapped error.
+// Is compares an ErrorWithContext with some target error to
+// determine whether they are considered equal.
+//
+// A receiver will match with a target that:
+// - is an ErrorWithContext or *ErrorWithContext, and
+// - has an equal or nil context, and
+// - has a nil error or
+// - an error which satisfies errors.Is(receiver.error, target.error)
+func (err ErrorWithContext) Is(target error) bool {
+	match := func(target *ErrorWithContext) bool {
+		return (target.ctx == nil || err.ctx == target.ctx) &&
+			(target.error == nil || errors.Is(err.error, target.error))
+	}
+
+	switch target := target.(type) {
+	case ErrorWithContext:
+		return match(&target)
+	case *ErrorWithContext:
+		return match(target)
+	default:
+		return false
+	}
+}
+
+// Unwrap returns the error wrapped by the ErrorWithContext.
 func (err ErrorWithContext) Unwrap() error {
 	return err.error
 }

--- a/errorWithContext_test.go
+++ b/errorWithContext_test.go
@@ -8,18 +8,88 @@ import (
 
 func TestErrorWithContextError(t *testing.T) {
 	// ARRANGE
+	// ARRANGE
+	testcases := []struct {
+		sut    ErrorWithContext
+		result string
+	}{
+		{sut: ErrorWithContext{}, result: "unknown error"},
+		{sut: ErrorWithContext{error: errors.New("wrapped error")}, result: "wrapped error"},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.result, func(t *testing.T) {
+			// ACT
+			got := tc.sut.Error()
+
+			// ASSERT
+			wanted := tc.result
+			if wanted != got {
+				t.Errorf("\nwanted %#v\ngot    %#v", wanted, got)
+			}
+		})
+	}
+}
+
+func TestErrorsIs(t *testing.T) {
+	// ARRANGE
+	ea := errors.New("a")
+	eb := errors.New("b")
+
+	testcases := []struct {
+		name   string
+		sut    error
+		target error
+		result bool
+	}{
+		{name: "ErrorWithContext{}:ErrorWithContext{}", sut: ErrorWithContext{}, target: ErrorWithContext{}, result: true},
+		{name: "ErrorWithContext{}:&ErrorWithContext{}", sut: ErrorWithContext{}, target: &ErrorWithContext{}, result: true},
+		{name: "&ErrorWithContext{}:ErrorWithContext{}", sut: &ErrorWithContext{}, target: ErrorWithContext{}, result: true},
+		{name: "&ErrorWithContext{}:&ErrorWithContext{}", sut: &ErrorWithContext{}, target: &ErrorWithContext{}, result: true},
+		{name: "ErrorWithContext{}:<some error>", sut: ErrorWithContext{}, target: errors.New(""), result: false},
+		{name: "&ErrorWithContext{}:<some error>", sut: &ErrorWithContext{}, target: errors.New(""), result: false},
+		{name: "ErrorWithContext{error:a}:ErrorWithContext{error:nil}", sut: ErrorWithContext{error: ea}, target: ErrorWithContext{}, result: true},
+		{name: "ErrorWithContext{error:a}:ErrorWithContext{error:a}", sut: ErrorWithContext{error: ea}, target: ErrorWithContext{error: ea}, result: true},
+		{name: "ErrorWithContext{error:a}:ErrorWithContext{error:b}", sut: ErrorWithContext{error: ea}, target: ErrorWithContext{error: eb}, result: false},
+		{name: "ErrorWithContext{error:a}:error(a)", sut: ErrorWithContext{error: ea}, target: ea, result: true},
+		{name: "ErrorWithContext{error:a}:error(b)", sut: ErrorWithContext{error: ea}, target: eb, result: false},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			// ASSERT
+			wanted := tc.result
+			got := errors.Is(tc.sut, tc.target)
+			if wanted != got {
+				t.Errorf("\nwanted %#v\ngot    %#v", wanted, got)
+			}
+		})
+	}
+}
+
+func TestErrorsAs(t *testing.T) {
+	// ARRANGE
 	ctx := context.Background()
 	err := errors.New("error")
-	sut := &ErrorWithContext{ctx, err}
 
-	// ACT
-	s := sut.Error()
-
-	// ASSERT
-	wanted := "error"
-	got := s
-	if wanted != got {
-		t.Errorf("\nwanted %#v\ngot    %#v", wanted, got)
+	testcases := []struct {
+		name   string
+		sut    error
+		target interface{}
+		result bool
+	}{
+		{name: "ErrorWithContext{}->ErrorWithContext{}", sut: ErrorWithContext{ctx, err}, target: ErrorWithContext{}, result: true},
+		{name: "ErrorWithContext{}->&ErrorWithContext{}", sut: ErrorWithContext{ctx, err}, target: &ErrorWithContext{}, result: true},
+		{name: "&ErrorWithContext{}->ErrorWithContext{}", sut: &ErrorWithContext{ctx, err}, target: ErrorWithContext{}, result: true},
+		{name: "&ErrorWithContext{}->&ErrorWithContext{}", sut: &ErrorWithContext{ctx, err}, target: &ErrorWithContext{}, result: true},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			// ASSERT
+			wanted := tc.result
+			got := errors.As(tc.sut, &tc.target)
+			if wanted != got {
+				t.Errorf("\nwanted %#v\ngot    %#v", wanted, got)
+			}
+		})
 	}
 }
 
@@ -32,11 +102,11 @@ func TestErrorWithContextContext(t *testing.T) {
 
 	testcases := []struct {
 		name   string
-		sut    *ErrorWithContext
+		sut    ErrorWithContext
 		result context.Context
 	}{
-		{name: "wraps error with context", sut: &ErrorWithContext{ctxa, &ErrorWithContext{ctxb, errors.New("error")}}, result: ctxb},
-		{name: "does not wrap error with context", sut: &ErrorWithContext{ctxa, errors.New("error")}, result: ctxa},
+		{name: "wraps error with context", sut: ErrorWithContext{ctxa, ErrorWithContext{ctxb, errors.New("error")}}, result: ctxb},
+		{name: "does not wrap error with context", sut: ErrorWithContext{ctxa, errors.New("error")}, result: ctxa},
 	}
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/errorWithContext_test.go
+++ b/errorWithContext_test.go
@@ -3,18 +3,20 @@ package errorcontext
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 )
 
 func TestErrorWithContextError(t *testing.T) {
 	// ARRANGE
-	// ARRANGE
 	testcases := []struct {
 		sut    ErrorWithContext
 		result string
 	}{
-		{sut: ErrorWithContext{}, result: "unknown error"},
-		{sut: ErrorWithContext{error: errors.New("wrapped error")}, result: "wrapped error"},
+		{sut: ErrorWithContext{}, result: "unspecified error with context"},
+		{sut: ErrorWithContext{error: errors.New("wrapped")}, result: "wrapped"},
+		{sut: ErrorWithContext{error: fmt.Errorf("%w: %w", errors.New("wrapped"), errors.New("cause"))}, result: "wrapped: cause"},
+		{sut: ErrorWithContext{error: errors.Join(errors.New("wrapped"), errors.New("cause"))}, result: "wrapped\ncause"},
 	}
 	for _, tc := range testcases {
 		t.Run(tc.result, func(t *testing.T) {
@@ -42,11 +44,7 @@ func TestErrorsIs(t *testing.T) {
 		result bool
 	}{
 		{name: "ErrorWithContext{}:ErrorWithContext{}", sut: ErrorWithContext{}, target: ErrorWithContext{}, result: true},
-		{name: "ErrorWithContext{}:&ErrorWithContext{}", sut: ErrorWithContext{}, target: &ErrorWithContext{}, result: true},
-		{name: "&ErrorWithContext{}:ErrorWithContext{}", sut: &ErrorWithContext{}, target: ErrorWithContext{}, result: true},
-		{name: "&ErrorWithContext{}:&ErrorWithContext{}", sut: &ErrorWithContext{}, target: &ErrorWithContext{}, result: true},
 		{name: "ErrorWithContext{}:<some error>", sut: ErrorWithContext{}, target: errors.New(""), result: false},
-		{name: "&ErrorWithContext{}:<some error>", sut: &ErrorWithContext{}, target: errors.New(""), result: false},
 		{name: "ErrorWithContext{error:a}:ErrorWithContext{error:nil}", sut: ErrorWithContext{error: ea}, target: ErrorWithContext{}, result: true},
 		{name: "ErrorWithContext{error:a}:ErrorWithContext{error:a}", sut: ErrorWithContext{error: ea}, target: ErrorWithContext{error: ea}, result: true},
 		{name: "ErrorWithContext{error:a}:ErrorWithContext{error:b}", sut: ErrorWithContext{error: ea}, target: ErrorWithContext{error: eb}, result: false},

--- a/factories.go
+++ b/factories.go
@@ -9,7 +9,7 @@ import (
 // New creates a new error with the supplied Context.
 // The error wraps a new error created by passing the
 // specified string to `errors.New()`.
-func New(ctx context.Context, s string) ErrorWithContext {
+func New(ctx context.Context, s string) error {
 	return ErrorWithContext{ctx, errors.New(s)}
 }
 
@@ -19,12 +19,65 @@ func New(ctx context.Context, s string) ErrorWithContext {
 //
 // Since `fmt.Errorf` is used, %w may be used in the format
 // string and an existing error passed as appropriate.
-func Errorf(ctx context.Context, format string, args ...interface{}) ErrorWithContext {
+func Errorf(ctx context.Context, format string, args ...interface{}) error {
 	return ErrorWithContext{ctx, fmt.Errorf(format, args...)}
 }
 
-// Wrap creates a new error wrapping the specified error
-// with the provided context.
-func Wrap(ctx context.Context, err error) ErrorWithContext {
-	return ErrorWithContext{ctx, err}
+// Wrap creates a new error wrapping at least one error with a
+// specified context.  However many arguments are specified,
+// if all errors are nil then the function returns nil.
+//
+// The error returned by the function wraps the specified error(s)
+// differently, depending on the number of non-nil errors specified.
+//
+// * 1 Error
+//
+// If only one non-nil error is specified, it is wrapped directly.
+//
+// * 2 Errors
+//
+// If two errors are specified and both are not nil, then the first
+// is wrapped formatted to indicate the second as the cause.  i.e. both
+// of the following are equivalent statements when a and b are non-nil:
+//
+//	errorcontext.Wrap(ctx, a, b)
+//	errorcontext.Wrap(ctx, fmt.Errorf("%w: %w", a, b))
+//
+// If either a or b are nil (but not both), the non-nil error is
+// wrapped directly.
+//
+// * 3 or More
+//
+// If three or more errors are specified, the function is
+// equivalent to:
+//
+//	errorcontext.Wrap(ctx, errors.Join(errs...))
+//
+// Unless all errors are nil, in which case nil is returned.
+func Wrap(ctx context.Context, err error, errs ...error) error {
+	switch len(errs) {
+	case 0:
+		if err == nil {
+			return nil
+		}
+		return ErrorWithContext{ctx, err}
+
+	case 1:
+		if err == nil && errs[0] == nil {
+			return nil
+		}
+		if err != nil && errs[0] != nil {
+			return ErrorWithContext{ctx, fmt.Errorf("%w: %w", err, errs[0])}
+		}
+		if err == nil {
+			err = errs[0]
+		}
+		return ErrorWithContext{ctx, err}
+
+	default:
+		if err = errors.Join(append([]error{err}, errs...)...); err != nil {
+			return ErrorWithContext{ctx, err}
+		}
+		return nil
+	}
 }

--- a/factories_test.go
+++ b/factories_test.go
@@ -37,7 +37,7 @@ func Test_New(t *testing.T) {
 	ctx := context.Background()
 
 	// ACT
-	sut := New(ctx, "some new error")
+	sut := New(ctx, "some new error").(ErrorWithContext)
 
 	// ASSERT
 	assert(t, sut, ctx, func() bool { return sut.error != nil }, "some new error")
@@ -49,7 +49,7 @@ func Test_Errorf(t *testing.T) {
 	err := errors.New("some error")
 
 	// ACT
-	sut := Errorf(ctx, "narrative: %w", err)
+	sut := Errorf(ctx, "narrative: %w", err).(ErrorWithContext)
 
 	// ASSERT
 	assert(t, sut, ctx, func() bool { return errors.Is(sut, err) }, "narrative: some error")
@@ -58,11 +58,58 @@ func Test_Errorf(t *testing.T) {
 func Test_Wrap(t *testing.T) {
 	// ARRANGE
 	ctx := context.Background()
-	err := errors.New("some error")
+	w := errors.New("wrapped")
+	c := errors.New("cause")
+	x := errors.New("extra")
 
-	// ACT
-	sut := Wrap(ctx, err)
+	type result struct {
+		string
+	}
+	testcases := []struct {
+		name string
+		args []error
+		*result
+	}{
+		{name: "all nil (1)", args: []error{nil}, result: nil},
+		{name: "all nil (2)", args: []error{nil, nil}, result: nil},
+		{name: "all nil (3)", args: []error{nil, nil, nil}, result: nil},
+		{name: "one non-nil (1)", args: []error{w}, result: &result{string: "wrapped"}},
+		{name: "1st of 2 non-nil", args: []error{w, nil}, result: &result{string: "wrapped"}},
+		{name: "2nd of 2 non-nil", args: []error{nil, w}, result: &result{string: "wrapped"}},
+		{name: "both of 2 non-nil", args: []error{w, c}, result: &result{string: "wrapped: cause"}},
+		{name: "1st of 3 non-nil", args: []error{w, nil, nil}, result: &result{string: "wrapped"}},
+		{name: "2nd of 3 non-nil", args: []error{nil, w, nil}, result: &result{string: "wrapped"}},
+		{name: "3rd of 3 non-nil", args: []error{nil, nil, w}, result: &result{string: "wrapped"}},
+		{name: "1st and 2nd of 3 non-nil", args: []error{w, c, nil}, result: &result{string: "wrapped\ncause"}},
+		{name: "1st and 3rd of 3 non-nil", args: []error{w, nil, c}, result: &result{string: "wrapped\ncause"}},
+		{name: "2nd and 3rd of 3 non-nil", args: []error{nil, w, c}, result: &result{string: "wrapped\ncause"}},
+		{name: "all of 3 non-nil", args: []error{w, c, x}, result: &result{string: "wrapped\ncause\nextra"}},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			// ACT
+			sut := Wrap(ctx, tc.args[0], tc.args[1:]...)
 
-	// ASSERT
-	assert(t, sut, ctx, func() bool { return sut.error == err }, "some error")
+			// ASSERT
+			switch {
+			case tc.result == nil && sut == nil:
+				return
+			case tc.result == nil && sut != nil:
+				t.Errorf("expected nil")
+			case tc.result != nil && sut == nil:
+				t.Errorf("expected error")
+			default:
+				for _, err := range tc.args {
+					if err != nil && !errors.Is(sut, err) {
+						t.Errorf("expected error to wrap: %v", err)
+					}
+				}
+				wanted := tc.result.string
+				got := sut.Error()
+				if wanted != got {
+					t.Errorf("\nwanted %#v\ngot    %#v", wanted, got)
+				}
+			}
+		})
+	}
 }

--- a/from.go
+++ b/from.go
@@ -10,9 +10,9 @@ import (
 // ErrorWithContext (and does not wrap one) the supplied `context` is
 // returned.
 func From(ctx context.Context, err error) context.Context {
-	wrapped := &ErrorWithContext{}
+	wrapped := ErrorWithContext{}
 	if errors.As(err, &wrapped) {
-		return wrapped.Context()
+		return wrapped.ctx
 	}
 	return ctx
 }

--- a/from_test.go
+++ b/from_test.go
@@ -8,7 +8,6 @@ import (
 )
 
 func TestFromErrorReturnsDefaultContextIfNoErrorWithContextIsFound(t *testing.T) {
-
 	// ARRANGE
 	ctx := context.Background()
 	err := errors.New("no context")
@@ -24,8 +23,25 @@ func TestFromErrorReturnsDefaultContextIfNoErrorWithContextIsFound(t *testing.T)
 	}
 }
 
-func TestFromErrorReturnsTheDeepestContext(t *testing.T) {
+func TestFromErrorReturnsContextFromAnErrorContext(t *testing.T) {
+	// ARRANGE
+	ctx := context.Background()
+	err := ErrorWithContext{ctx: ctx}
 
+	type key string
+
+	// ACT
+	newctx := context.WithValue(ctx, key("k"), "value")
+	got := From(newctx, err)
+
+	// ASSERT
+	wanted := ctx
+	if wanted != got {
+		t.Errorf("wanted %v, got %v", ctx, got)
+	}
+}
+
+func TestFromErrorReturnsTheDeepestContext(t *testing.T) {
 	// ARRANGE
 	type keytype int
 	const key keytype = 1
@@ -33,7 +49,7 @@ func TestFromErrorReturnsTheDeepestContext(t *testing.T) {
 	initial := context.Background()
 	ctx := context.WithValue(initial, key, "value")
 
-	err := &ErrorWithContext{ctx: ctx, error: errors.New("no context")}
+	err := ErrorWithContext{ctx: ctx, error: errors.New("no context")}
 	buried := fmt.Errorf("buried: %w", err)
 	inner := fmt.Errorf("inner: %w", buried)
 	outer := fmt.Errorf("outer: %w", inner)


### PR DESCRIPTION
When wrapping multiple errors it would be convenient to use Wrap() directly, rather than having to condense multiple errors into a single one to wrap.

Common use cases are:
- attaching a sentinel error to an error cause (2 errors)
- wrapping a sentinel with multiple errors

Wrap() has been extended to support a variadic list of errors in addition to any explicit error.  In this way, the existing usage with a single error parameter is not affected.