### PR TITLE
Wrap() extended to support wrapping multiple errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,4 +15,4 @@
 *.out
 
 # Dependency directories (remove the comment below to include it)
-# vendor/
+.vscode

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,0 @@
-{
-    "sonarlint.connectedMode.project": {
-        "connectionId": "SonarCloud (blugnu)",
-        "projectKey": "blugnu:errorcontext"
-    }
-}

--- a/errorWithContext_test.go
+++ b/errorWithContext_test.go
@@ -3,18 +3,20 @@ package errorcontext
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 )
 
 func TestErrorWithContextError(t *testing.T) {
 	// ARRANGE
-	// ARRANGE
 	testcases := []struct {
 		sut    ErrorWithContext
 		result string
 	}{
-		{sut: ErrorWithContext{}, result: "unknown error"},
-		{sut: ErrorWithContext{error: errors.New("wrapped error")}, result: "wrapped error"},
+		{sut: ErrorWithContext{}, result: "unspecified error with context"},
+		{sut: ErrorWithContext{error: errors.New("wrapped")}, result: "wrapped"},
+		{sut: ErrorWithContext{error: fmt.Errorf("%w: %w", errors.New("wrapped"), errors.New("cause"))}, result: "wrapped: cause"},
+		{sut: ErrorWithContext{error: errors.Join(errors.New("wrapped"), errors.New("cause"))}, result: "wrapped\ncause"},
 	}
 	for _, tc := range testcases {
 		t.Run(tc.result, func(t *testing.T) {
@@ -42,11 +44,7 @@ func TestErrorsIs(t *testing.T) {
 		result bool
 	}{
 		{name: "ErrorWithContext{}:ErrorWithContext{}", sut: ErrorWithContext{}, target: ErrorWithContext{}, result: true},
-		{name: "ErrorWithContext{}:&ErrorWithContext{}", sut: ErrorWithContext{}, target: &ErrorWithContext{}, result: true},
-		{name: "&ErrorWithContext{}:ErrorWithContext{}", sut: &ErrorWithContext{}, target: ErrorWithContext{}, result: true},
-		{name: "&ErrorWithContext{}:&ErrorWithContext{}", sut: &ErrorWithContext{}, target: &ErrorWithContext{}, result: true},
 		{name: "ErrorWithContext{}:<some error>", sut: ErrorWithContext{}, target: errors.New(""), result: false},
-		{name: "&ErrorWithContext{}:<some error>", sut: &ErrorWithContext{}, target: errors.New(""), result: false},
 		{name: "ErrorWithContext{error:a}:ErrorWithContext{error:nil}", sut: ErrorWithContext{error: ea}, target: ErrorWithContext{}, result: true},
 		{name: "ErrorWithContext{error:a}:ErrorWithContext{error:a}", sut: ErrorWithContext{error: ea}, target: ErrorWithContext{error: ea}, result: true},
 		{name: "ErrorWithContext{error:a}:ErrorWithContext{error:b}", sut: ErrorWithContext{error: ea}, target: ErrorWithContext{error: eb}, result: false},

--- a/factories.go
+++ b/factories.go
@@ -9,7 +9,7 @@ import (
 // New creates a new error with the supplied Context.
 // The error wraps a new error created by passing the
 // specified string to `errors.New()`.
-func New(ctx context.Context, s string) ErrorWithContext {
+func New(ctx context.Context, s string) error {
 	return ErrorWithContext{ctx, errors.New(s)}
 }
 
@@ -19,12 +19,65 @@ func New(ctx context.Context, s string) ErrorWithContext {
 //
 // Since `fmt.Errorf` is used, %w may be used in the format
 // string and an existing error passed as appropriate.
-func Errorf(ctx context.Context, format string, args ...interface{}) ErrorWithContext {
+func Errorf(ctx context.Context, format string, args ...interface{}) error {
 	return ErrorWithContext{ctx, fmt.Errorf(format, args...)}
 }
 
-// Wrap creates a new error wrapping the specified error
-// with the provided context.
-func Wrap(ctx context.Context, err error) ErrorWithContext {
-	return ErrorWithContext{ctx, err}
+// Wrap creates a new error wrapping at least one error with a
+// specified context.  However many arguments are specified,
+// if all errors are nil then the function returns nil.
+//
+// The error returned by the function wraps the specified error(s)
+// differently, depending on the number of non-nil errors specified.
+//
+// * 1 Error
+//
+// If only one non-nil error is specified, it is wrapped directly.
+//
+// * 2 Errors
+//
+// If two errors are specified and both are not nil, then the first
+// is wrapped formatted to indicate the second as the cause.  i.e. both
+// of the following are equivalent statements when a and b are non-nil:
+//
+//	errorcontext.Wrap(ctx, a, b)
+//	errorcontext.Wrap(ctx, fmt.Errorf("%w: %w", a, b))
+//
+// If either a or b are nil (but not both), the non-nil error is
+// wrapped directly.
+//
+// * 3 or More
+//
+// If three or more errors are specified, the function is
+// equivalent to:
+//
+//	errorcontext.Wrap(ctx, errors.Join(errs...))
+//
+// Unless all errors are nil, in which case nil is returned.
+func Wrap(ctx context.Context, err error, errs ...error) error {
+	switch len(errs) {
+	case 0:
+		if err == nil {
+			return nil
+		}
+		return ErrorWithContext{ctx, err}
+
+	case 1:
+		if err == nil && errs[0] == nil {
+			return nil
+		}
+		if err != nil && errs[0] != nil {
+			return ErrorWithContext{ctx, fmt.Errorf("%w: %w", err, errs[0])}
+		}
+		if err == nil {
+			err = errs[0]
+		}
+		return ErrorWithContext{ctx, err}
+
+	default:
+		if err = errors.Join(append([]error{err}, errs...)...); err != nil {
+			return ErrorWithContext{ctx, err}
+		}
+		return nil
+	}
 }

--- a/factories_test.go
+++ b/factories_test.go
@@ -37,7 +37,7 @@ func Test_New(t *testing.T) {
 	ctx := context.Background()
 
 	// ACT
-	sut := New(ctx, "some new error")
+	sut := New(ctx, "some new error").(ErrorWithContext)
 
 	// ASSERT
 	assert(t, sut, ctx, func() bool { return sut.error != nil }, "some new error")
@@ -49,7 +49,7 @@ func Test_Errorf(t *testing.T) {
 	err := errors.New("some error")
 
 	// ACT
-	sut := Errorf(ctx, "narrative: %w", err)
+	sut := Errorf(ctx, "narrative: %w", err).(ErrorWithContext)
 
 	// ASSERT
 	assert(t, sut, ctx, func() bool { return errors.Is(sut, err) }, "narrative: some error")
@@ -58,11 +58,58 @@ func Test_Errorf(t *testing.T) {
 func Test_Wrap(t *testing.T) {
 	// ARRANGE
 	ctx := context.Background()
-	err := errors.New("some error")
+	w := errors.New("wrapped")
+	c := errors.New("cause")
+	x := errors.New("extra")
 
-	// ACT
-	sut := Wrap(ctx, err)
+	type result struct {
+		string
+	}
+	testcases := []struct {
+		name string
+		args []error
+		*result
+	}{
+		{name: "all nil (1)", args: []error{nil}, result: nil},
+		{name: "all nil (2)", args: []error{nil, nil}, result: nil},
+		{name: "all nil (3)", args: []error{nil, nil, nil}, result: nil},
+		{name: "one non-nil (1)", args: []error{w}, result: &result{string: "wrapped"}},
+		{name: "1st of 2 non-nil", args: []error{w, nil}, result: &result{string: "wrapped"}},
+		{name: "2nd of 2 non-nil", args: []error{nil, w}, result: &result{string: "wrapped"}},
+		{name: "both of 2 non-nil", args: []error{w, c}, result: &result{string: "wrapped: cause"}},
+		{name: "1st of 3 non-nil", args: []error{w, nil, nil}, result: &result{string: "wrapped"}},
+		{name: "2nd of 3 non-nil", args: []error{nil, w, nil}, result: &result{string: "wrapped"}},
+		{name: "3rd of 3 non-nil", args: []error{nil, nil, w}, result: &result{string: "wrapped"}},
+		{name: "1st and 2nd of 3 non-nil", args: []error{w, c, nil}, result: &result{string: "wrapped\ncause"}},
+		{name: "1st and 3rd of 3 non-nil", args: []error{w, nil, c}, result: &result{string: "wrapped\ncause"}},
+		{name: "2nd and 3rd of 3 non-nil", args: []error{nil, w, c}, result: &result{string: "wrapped\ncause"}},
+		{name: "all of 3 non-nil", args: []error{w, c, x}, result: &result{string: "wrapped\ncause\nextra"}},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			// ACT
+			sut := Wrap(ctx, tc.args[0], tc.args[1:]...)
 
-	// ASSERT
-	assert(t, sut, ctx, func() bool { return sut.error == err }, "some error")
+			// ASSERT
+			switch {
+			case tc.result == nil && sut == nil:
+				return
+			case tc.result == nil && sut != nil:
+				t.Errorf("expected nil")
+			case tc.result != nil && sut == nil:
+				t.Errorf("expected error")
+			default:
+				for _, err := range tc.args {
+					if err != nil && !errors.Is(sut, err) {
+						t.Errorf("expected error to wrap: %v", err)
+					}
+				}
+				wanted := tc.result.string
+				got := sut.Error()
+				if wanted != got {
+					t.Errorf("\nwanted %#v\ngot    %#v", wanted, got)
+				}
+			}
+		})
+	}
 }

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/blugnu/errorcontext
 
-go 1.16
+go 1.20
 
 retract v0.1.0  // published with incorrect module name in go.mod


### PR DESCRIPTION
Adds support for Wrap() to wrap multiple errors; although a new feature, it is a patch release because it does not change the behaviour of existing code