### PR TITLE
errorcontext.Wrap() simplified and errors.Join() introduced

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -1,7 +1,0 @@
-name: module-pipeline
-on:
-  - push
-jobs:
-  module-qa:
-    uses: blugnu/.reusable/.github/workflows/module.yml@master
-    secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,7 @@
+name: release
+on:
+  - push
+jobs:
+  release:
+    uses: blugnu/.reusable/.github/workflows/pipeline.module-release.yml@master
+    secrets: inherit

--- a/.gitignore
+++ b/.gitignore
@@ -14,5 +14,5 @@
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
 
-# Dependency directories (remove the comment below to include it)
+# IDE settings
 .vscode

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,3 @@
+version: 1
+build:
+  skip: true

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,6 @@
+{
+    "MD013": { "line_length": 200 },
+    "MD014": false, // allow $ prompts in backtick blocks (shell command examples)
+    "MD033": false, // allow inline html
+    "MD041": false  // allow non heading first line
+}

--- a/README.md
+++ b/README.md
@@ -35,6 +35,17 @@ A number of factory functions are provided to create/wrap contextual errors in a
 
 All functions require a `Context`.
 
+Factory functions are provided to create/wrap contextual errors in a variety of circumstances:
+
+| function | description | use in place of ... |
+| -- | -- | -- |
+| `New(ctx, s)` | creates a new error wrapping a `Context` with an error created using `errors.New()` with a supplied string | `errors.New(s)` |
+| `Errorf(ctx, format, args...)` | creates a new error using `fmt.Errorf()` given a format string and args | `fmt.Errorf(s, args...)` |
+| `Join(ctx, err...)` | uses `errors.Join()` to consolidate multiple errors and wrap the result (if not `nil`) with a specified context | `errors.Join(err1, err2, ...)` |
+| `Wrap(ctx, err...)` | creates a new error, wrapping a `Context` with one or two specified errors | `fmt.Errorf("%w: %w", err1, err2)`<br>or<br>`errors.Wrap(err1, err2)` |
+
+All functions require a `Context`.
+
 ### _example: New()_
 ```golang
     if len(sql) == 0 {

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <div align="center" style="margin-bottom:20px">
   <img src=".assets/banner.png" alt="errorcontext" />
   <div align="center">
-    <a href="https://github.com/blugnu/errorcontext/actions/workflows/pipeline.yml"><img alt="build-status" src="https://github.com/blugnu/errorcontext/actions/workflows/pipeline.yml/badge.svg"/></a>
+    <a href="https://github.com/blugnu/errorcontext/actions/workflows/release.yml"><img alt="build-status" src="https://github.com/blugnu/errorcontext/actions/workflows/release.yml/badge.svg"/></a>
     <a href="https://goreportcard.com/report/github.com/blugnu/errorcontext" ><img alt="go report" src="https://goreportcard.com/badge/github.com/blugnu/errorcontext"/></a>
     <a><img alt="go version >= 1.14" src="https://img.shields.io/github/go-mod/go-version/blugnu/errorcontext?style=flat-square"/></a>
     <a href="https://github.com/blugnu/errorcontext/blob/master/LICENSE"><img alt="MIT License" src="https://img.shields.io/github/license/blugnu/errorcontext?color=%234275f5&style=flat-square"/></a>
@@ -14,26 +14,17 @@
 
 > **TL;DR**: to get started, `go get github.com/blugnu/errorcontext` (or later, if available)
 
-A `go` package providing an `error` implementation that wraps an `error` together with a supplied `Context`.
+A `go` package providing an `error` implementation that wraps an `error` together with a `context.Context`.
 
 ## History
 
-This module is a ground-up re-write of the previously released (and still available) `go-errorcontext` module.  This new implementation incorporate a number of improvements and simplifies the API.
+This module is a ground-up re-write of the previously released (and still available) `go-errorcontext` module.
+This new implementation incorporates a number of improvements and simplifies the API.
 
-It has been renamed as `errorcontext` rather than being a v2 release of the original as the opportunity has also been taken to remove the superfluous and cumbersome `go-` prefix from the module name.
-
+It has been renamed as `errorcontext` rather than being a v2 release in order to remove the cumbersome `go-` prefix
+from the module name.
 
 ## Creating Errors
-
-A number of factory functions are provided to create/wrap contextual errors in a variety of circumstances:
-
-| function | description |
-| -- | -- |
-| `New(ctx, s)` | creates a new error using `errors.New()` given a string |
-| `Errorf(ctx, format, args...)` | creates a new error using `fmt.Errorf()` given a format string and args |
-| `Wrap(ctx, err [, err, err])` | creates an error wrapping one or more existing errors together with a specified `Context` |
-
-All functions require a `Context`.
 
 Factory functions are provided to create/wrap contextual errors in a variety of circumstances:
 
@@ -47,6 +38,7 @@ Factory functions are provided to create/wrap contextual errors in a variety of 
 All functions require a `Context`.
 
 ### _example: New()_
+
 ```golang
     if len(sql) == 0 {
         return errorcontext.New(ctx, "a sql statement is required")
@@ -54,45 +46,71 @@ All functions require a `Context`.
 ```
 
 ### _example: Errorf()_
-_1. formatting a new error_
+
+#### _1. formatting a new error_
+
 ```golang
     if len(pwd) < minpwdlen {
         return errorcontext.Errorf(ctx, "password must be at least %d chars", minpwdlen)
     }
 ```
-_2. wrapping an existing error with textual context_
+
+#### _2. adding narration to an error_
+
 ```golang
     if err := db.QueryContext(ctx, sql, args); err != nil {
         return errorcontext.Errorf(ctx, "db query: %w", err)
     }
 ```
 
+### _example: Join()_
+
+Wrapping an arbitrary collection of possibly `nil` errors:
+
+```golang
+    err1 := Operation1(ctx)
+    err2 := Operation2(ctx)
+    if err := errorcontext.Join(ctx, err1, err2); err != nil {
+        return err
+    }
+```
+
 ### _example: Wrap()_
-_1. wrapping an existing error_
+
+#### _1. wrapping an existing error_
+
 ```golang
     if err := db.QueryContext(ctx, sql, args); err != nil {
         return errorcontext.Wrap(ctx, err)
     }
 ```
-_2. wrapping two errors_
-When wrapping two (2) errors they are composed into an `error: cause` error chain, equivalent to `Wrap(ctx, fmt.Errorf("%w: %w", err1, err2))`; this is a useful pattern for attaching a sentinel error to some arbitrary error, typically to simplify testing:
+
+#### _2. wrapping two errors_
+
+When wrapping two (2) errors they are composed into an `error: cause` error chain,
+equivalent to `Wrap(ctx, fmt.Errorf("%w: %w", err1, err2))`; this is a useful pattern for
+attaching a sentinel error to some arbitrary error, typically to simplify testing:
+
 ```golang
     if err := db.QueryContext(ctx, sql, args); err != nil {
         return errorcontext.Wrap(ctx, ErrQueryFailed, err)
     }
 ```
-A test of a function containing this code can check for the sentinel error without being coupled to details of the error returned by the function called by the function under test, for example:
+
+A test of a function containing this code can check for the sentinel error without being coupled
+to details of the error returned by the function called by the function under test, for example:
+
 ```golang
     if err := Foo(ctx); !errors.Is(err, ErrQueryFailed) {
         t.Errorf("expected ErrQueryFailed, got %v", err)
     }
 ```
-_3. wrapping three or more errors_
-When wrapping three (3) or more errors they are composed into a collection of errors, equivalent to `Wrap(ctx, errors.Join(err1, err2, err3, ...))`.
 
 ## Working With Errors
 
-The`context` captured by an `ErrorWithContext` may be obtained (if required) by determining whether an `error` is (or wraps) an `ErrorWithContext`.  If an `ErrorWithContext` is available, the `Context()` function may then be called to obtain the `Context` associated with the error:
+The`Context` captured by an `ErrorWithContext` may be obtained (if required) by determining whether
+an `error` is (or wraps) an `ErrorWithContext`.  If an `ErrorWithContext` is available from an `error`
+the `Context()` function may then be called to obtain the `Context` associated with the error:
 
 ```golang
 ctx := context.Background()
@@ -113,7 +131,9 @@ if err := Foo(ctx); err != nil {
 }
 ```
 
-The `errorcontext.From()` helper function provides a convenient way to do this, accepting a default `Context` (usually the current context) to use if no `Context` is captured by the `error`, simplifying the above to:
+The `errorcontext.From()` helper function provides a convenient way to do this, accepting a
+default `Context` (usually the current context) to use if no `Context` is captured by the `error`,
+simplifying the above to:
 
 ```golang
     if err := Foo(ctx); err != nil {
@@ -122,23 +142,25 @@ The `errorcontext.From()` helper function provides a convenient way to do this, 
         log.Error(err)
     }
 ```
-> _**NOTE:** The `Context()` function will recursively unwrap any further `ErrorWithContext` errors to return the `Context` associated with the most-wrapped error possible.  This ensures that the most enriched `Context` that is available is returned._
+
+> _**NOTE:** The `Context()` function will recursively unwrap any further `ErrorWithContext` errors
+> to return the `Context` associated with the most-wrapped error possible.  This ensures that the
+> most enriched `Context` that is available is returned._
 
 <br>
 <br>
 
 # Intended Use
 
-`ErrorWithContext` is intended to reduce "chatter" when logging errors, particularly when using a context logger to enrich structured logs.
-
-<br>
+`ErrorWithContext` is intended to reduce "chatter" when logging errors, particularly when using a context
+logger to enrich structured logs.
 
 ## The Problem
 
 1. A `Context` enriched by a call hierarchy is _most_ enriched at the deepest levels of a call hierarchy.
 2. Idiomatically wrapped errors provide the greatest narrative at the shallowest level of that call hierarchy.
 
-This is perhaps best illustrated with an example:
+This may be demonstrated with an example:
 
 ```golang
 func Bar(ctx context.Context) error {
@@ -165,9 +187,15 @@ This produces the output:
 
 > `FATAL message="Foo: Bar: not implemented"`
 
-i.e. the error `string` describes the origin of the error.  However, the `Context` available at the point at which the error is logged contains none of the keys which might be used by a context logger to enrich a log entry with additional information not available in the error string.
+The error `string`, as logged, describes the _origin_ of the error.
 
-If a context logger is used to log an error with that enrichment, deep within the call hierarchy, the error string lacks the additional narrative obtained by passing the error back up the call hierarchy.  But if every function that receives an error does this then the log becomes very noisy and potentially confusing if context logging is not consistently used:
+However, the `Context` available at the point at which the error is logged contains none of the keys which might
+be used by a context logger to enrich a log entry with additional information not available in the error string.
+
+If a context logger is used to log an error with that enrichment, deep within the call hierarchy, the error string
+lacks the additional narrative obtained by passing the error back up the call hierarchy.  But if every function
+that receives an error does this then the log becomes very noisy and potentially confusing if context logging
+is not consistently used:
 
 ```golang
 func Bar(ctx context.Context) error {
@@ -193,21 +221,30 @@ func main() {
 }
 ```
 
-Which might produce log output similar to: 
-> `ERROR message="not implemented"`<br/> `ERROR foo=42 message="Bar: not implemented"`<br/> `FATAL message="Foo: Bar: not implemented"`
+Which might produce log output similar to:
 
-_yes, there is a lot else wrong with the error handling and reporting in this example; it is intended only as an illustration and as such deliberately presents a potential worst case_
+> `ERROR message="not implemented"`<br>
+> `ERROR foo=42 message="Bar: not implemented"`<br>
+> `FATAL message="Foo: Bar: not implemented"`
 
-<br/>
+_there is a lot else wrong with the error handling and reporting in this example;
+it is intended only as an illustration and as such deliberately presents a potential worst case_
 
-`ErrorWithContext` addresses this dilemma by providing a mechanism for returning the context at each level back _up_ the call hierarchy together with the error.
+<br>
 
-A simple convention then ensures that the error is logged _only once_ **and** with the greatest possible context information available from the source of the error.
+`ErrorWithContext` addresses this problem by providing a mechanism for returning the context at each
+level back _up_ the call hierarchy together with the error that occurred.
+
+A simple convention then ensures that the error is logged _only once_ **and** with the greatest
+possible context information available from the source of the error.
 
 The convention has two parts:
 
-1. If an error is returned, it is _**not** logged_ but returned as an _`ErrorWithContext`_ (if a local `Context` is available, or returned without context otherwise)
-2. If an error is _**not**_ returned (usually at the effective or actual root of the call hierarchy) it is logged, extracting any `Context` from the `error` and using a context logger initialized from that context
+1. If an error is returned, it is _**not** logged_ but returned as an _`ErrorWithContext`_
+   (if a local `Context` is available), or at least returned without context
+
+2. If an error is _**not**_ returned (usually at the effective or actual root of a call hierarchy, e.g. in a http
+   handler) it is logged using a context logger initialized from context captured with the error (if any)
 
 Informational and warning logs may of course continue to be emitted at every level in the call hierarchy.
 
@@ -241,4 +278,5 @@ which might result in output similar to:
 
 > `FATAL foo=42 message="Foo: Bar: not implemented"`
 
-Error handling is simplified and idiomatic, with the benefit of both fully enriched context logging _and_ descriptive error messages.
+Error handling is simplified and idiomatic, with the benefit of both fully enriched context logging
+_and_ descriptive error messages.

--- a/factories.go
+++ b/factories.go
@@ -6,12 +6,7 @@ import (
 	"fmt"
 )
 
-// New creates a new error with the supplied Context.
-// The error wraps a new error created by passing the
-// specified string to `errors.New()`.
-func New(ctx context.Context, s string) error {
-	return ErrorWithContext{ctx, errors.New(s)}
-}
+var ErrIllegalOperation = errors.New("illegal operation")
 
 // Errorf creates a new error with the supplied Context.
 // The error wraps an error created by passing a supplied
@@ -23,22 +18,41 @@ func Errorf(ctx context.Context, format string, args ...interface{}) error {
 	return ErrorWithContext{ctx, fmt.Errorf(format, args...)}
 }
 
-// Wrap creates a new error wrapping at least one error with a
-// specified context.  However many arguments are specified,
-// if all errors are nil then the function returns nil.
+// Join creates a new error wrapping any number of supplied errors
+// with a specified context.
+//
+// If all errors are nil then the function returns nil.
+func Join(ctx context.Context, errs ...error) error {
+	if err := errors.Join(errs...); err != nil {
+		return ErrorWithContext{ctx, err}
+	}
+	return nil
+}
+
+// New creates a new error with the supplied Context.
+// The error wraps a new error created by passing the
+// specified string to `errors.New()`.
+func New(ctx context.Context, s string) error {
+	return ErrorWithContext{ctx, errors.New(s)}
+}
+
+// Wrap creates a new error wrapping one or two errors with a
+// specified context.  If both errors are nil then the function
+// returns nil.
 //
 // The error returned by the function wraps the specified error(s)
 // differently, depending on the number of non-nil errors specified.
 //
-// * 1 Error
+// # Called with 1 Error
 //
-// If only one non-nil error is specified, it is wrapped directly.
+// If only one non-nil error is specified it is wrapped directly.
 //
-// * 2 Errors
+// # Called with 2 Errors
 //
-// If two errors are specified and both are not nil, then the first
-// is wrapped formatted to indicate the second as the cause.  i.e. both
-// of the following are equivalent statements when a and b are non-nil:
+// If two errors (a, b) are specified and both are not nil, then both
+// errors are wrapped within a new error of the form "a: b".
+//
+// i.e. the following are equivalent statements when a and b are non-nil:
 //
 //	errorcontext.Wrap(ctx, a, b)
 //	errorcontext.Wrap(ctx, fmt.Errorf("%w: %w", a, b))
@@ -46,38 +60,34 @@ func Errorf(ctx context.Context, format string, args ...interface{}) error {
 // If either a or b are nil (but not both), the non-nil error is
 // wrapped directly.
 //
-// * 3 or More
+// # Called with > 2 errors
 //
-// If three or more errors are specified, the function is
-// equivalent to:
-//
-//	errorcontext.Wrap(ctx, errors.Join(errs...))
-//
-// Unless all errors are nil, in which case nil is returned.
+// The function will panic with ErrIllegalOperation if called
+// with 3 or more error arguments, whether or not any or all of
+// those arguments are nil.  To wrap three or more errors use
+// the errorcontext.Join function.
 func Wrap(ctx context.Context, err error, errs ...error) error {
-	switch len(errs) {
-	case 0:
-		if err == nil {
-			return nil
-		}
-		return ErrorWithContext{ctx, err}
-
+	switch 1 + len(errs) {
 	case 1:
-		if err == nil && errs[0] == nil {
-			return nil
-		}
-		if err != nil && errs[0] != nil {
-			return ErrorWithContext{ctx, fmt.Errorf("%w: %w", err, errs[0])}
-		}
-		if err == nil {
-			err = errs[0]
-		}
-		return ErrorWithContext{ctx, err}
-
-	default:
-		if err = errors.Join(append([]error{err}, errs...)...); err != nil {
+		if err != nil {
 			return ErrorWithContext{ctx, err}
 		}
-		return nil
+
+	case 2:
+		switch {
+		case err == nil && errs[0] != nil:
+			return ErrorWithContext{ctx, errs[0]}
+
+		case err != nil && errs[0] == nil:
+			return ErrorWithContext{ctx, err}
+
+		case err != nil && errs[0] != nil:
+			return ErrorWithContext{ctx, fmt.Errorf("%w: %w", err, errs[0])}
+		}
+
+	default:
+		panic(fmt.Errorf("errorcontext.Wrap: %w: may only be called with 1 or 2 errors; "+
+			"use errorcontext.Join for > 2 error arguments", ErrIllegalOperation))
 	}
+	return nil
 }

--- a/factories_test.go
+++ b/factories_test.go
@@ -4,112 +4,162 @@ import (
 	"context"
 	"errors"
 	"testing"
+
+	"github.com/blugnu/test"
 )
 
-func assert(t *testing.T, sut ErrorWithContext, wantCtx context.Context, errorIsWanted func() bool, wantString string) {
-	t.Run("wraps context", func(t *testing.T) {
-		wanted := wantCtx
-		got := sut.ctx
-		if wanted != got {
-			t.Errorf("\nwanted %#v\ngot    %#v", wanted, got)
-		}
-	})
-
-	t.Run("wraps error", func(t *testing.T) {
-		wanted := true
-		got := errorIsWanted()
-		if wanted != got {
-			t.Errorf("\nwanted %#v\ngot    %#v", wanted, got)
-		}
-	})
-
-	t.Run("Error()", func(t *testing.T) {
-		wanted := wantString
-		got := sut.Error()
-		if wanted != got {
-			t.Errorf("\nwanted %#v\ngot    %#v", wanted, got)
-		}
-	})
-}
-
-func Test_New(t *testing.T) {
+func TestFactories(t *testing.T) {
 	// ARRANGE
 	ctx := context.Background()
+	a := errors.New("a")
+	b := errors.New("b")
 
-	// ACT
-	sut := New(ctx, "some new error").(ErrorWithContext)
-
-	// ASSERT
-	assert(t, sut, ctx, func() bool { return sut.error != nil }, "some new error")
-}
-
-func Test_Errorf(t *testing.T) {
-	// ARRANGE
-	ctx := context.Background()
-	err := errors.New("some error")
-
-	// ACT
-	sut := Errorf(ctx, "narrative: %w", err).(ErrorWithContext)
-
-	// ASSERT
-	assert(t, sut, ctx, func() bool { return errors.Is(sut, err) }, "narrative: some error")
-}
-
-func Test_Wrap(t *testing.T) {
-	// ARRANGE
-	ctx := context.Background()
-	w := errors.New("wrapped")
-	c := errors.New("cause")
-	x := errors.New("extra")
-
-	type result struct {
-		string
-	}
 	testcases := []struct {
-		name string
-		args []error
-		*result
+		scenario string
+		exec     func(t *testing.T)
 	}{
-		{name: "all nil (1)", args: []error{nil}, result: nil},
-		{name: "all nil (2)", args: []error{nil, nil}, result: nil},
-		{name: "all nil (3)", args: []error{nil, nil, nil}, result: nil},
-		{name: "one non-nil (1)", args: []error{w}, result: &result{string: "wrapped"}},
-		{name: "1st of 2 non-nil", args: []error{w, nil}, result: &result{string: "wrapped"}},
-		{name: "2nd of 2 non-nil", args: []error{nil, w}, result: &result{string: "wrapped"}},
-		{name: "both of 2 non-nil", args: []error{w, c}, result: &result{string: "wrapped: cause"}},
-		{name: "1st of 3 non-nil", args: []error{w, nil, nil}, result: &result{string: "wrapped"}},
-		{name: "2nd of 3 non-nil", args: []error{nil, w, nil}, result: &result{string: "wrapped"}},
-		{name: "3rd of 3 non-nil", args: []error{nil, nil, w}, result: &result{string: "wrapped"}},
-		{name: "1st and 2nd of 3 non-nil", args: []error{w, c, nil}, result: &result{string: "wrapped\ncause"}},
-		{name: "1st and 3rd of 3 non-nil", args: []error{w, nil, c}, result: &result{string: "wrapped\ncause"}},
-		{name: "2nd and 3rd of 3 non-nil", args: []error{nil, w, c}, result: &result{string: "wrapped\ncause"}},
-		{name: "all of 3 non-nil", args: []error{w, c, x}, result: &result{string: "wrapped\ncause\nextra"}},
+		// Errorf tests
+		{scenario: "Errorf(\"narrative: %w\",a)",
+			exec: func(t *testing.T) {
+				// ACT
+				result := Errorf(ctx, "narrative: %w", a)
+
+				// ASSERT
+				test.IsTrue(t, result != nil)
+				test.That(t, result.Error()).Equals("narrative: a")
+				if result, ok := test.IsType[ErrorWithContext](t, result); ok {
+					test.Error(t, result).Is(a)
+				}
+			},
+		},
+
+		// Join tests
+		{scenario: "Join(nil)",
+			exec: func(t *testing.T) {
+				// ACT
+				result := Join(ctx, nil)
+
+				// ASSERT
+				test.IsNil(t, result)
+			},
+		},
+		{scenario: "Join(a)",
+			exec: func(t *testing.T) {
+				// ACT
+				result := Join(ctx, a)
+
+				// ASSERT
+				test.IsTrue(t, result != nil)
+				test.That(t, result.Error()).Equals("a")
+				if result, ok := test.IsType[ErrorWithContext](t, result); ok {
+					test.Error(t, result).Is(a)
+				}
+			},
+		},
+		{scenario: "Join(a,b)",
+			exec: func(t *testing.T) {
+				// ACT
+				result := Join(ctx, a, b)
+
+				// ASSERT
+				test.IsTrue(t, result != nil)
+				test.That(t, result.Error()).Equals("a\nb")
+				if result, ok := test.IsType[ErrorWithContext](t, result); ok {
+					test.Error(t, result).Is(a)
+					test.Error(t, result).Is(b)
+				}
+			},
+		},
+
+		// New tests
+		{scenario: "New(ctx, \"a\")",
+			exec: func(t *testing.T) {
+				// ACT
+				result := New(ctx, "a")
+
+				// ASSERT
+				test.IsTrue(t, result != nil)
+				test.That(t, result.Error()).Equals("a")
+				_, _ = test.IsType[ErrorWithContext](t, result)
+			},
+		},
+
+		// Wrap tests
+		{scenario: "Wrap(nil)",
+			exec: func(t *testing.T) {
+				// ACT
+				result := Wrap(ctx, nil)
+
+				// ASSERT
+				test.IsNil(t, result)
+			},
+		},
+		{scenario: "Wrap(a)",
+			exec: func(t *testing.T) {
+				// ACT
+				result := Wrap(ctx, a)
+
+				// ASSERT
+				test.IsTrue(t, result != nil)
+				test.That(t, result.Error()).Equals("a")
+				if result, ok := test.IsType[ErrorWithContext](t, result); ok {
+					test.Error(t, result).Is(a)
+				}
+			},
+		},
+		{scenario: "Wrap(a, nil)",
+			exec: func(t *testing.T) {
+				// ACT
+				result := Wrap(ctx, a, nil)
+
+				// ASSERT
+				test.IsTrue(t, result != nil)
+				test.That(t, result.Error()).Equals("a")
+				if result, ok := test.IsType[ErrorWithContext](t, result); ok {
+					test.Error(t, result).Is(a)
+				}
+			},
+		},
+		{scenario: "Wrap(nil,b)",
+			exec: func(t *testing.T) {
+				// ACT
+				result := Wrap(ctx, nil, b)
+
+				// ASSERT
+				test.IsTrue(t, result != nil)
+				test.That(t, result.Error()).Equals("b")
+				if result, ok := test.IsType[ErrorWithContext](t, result); ok {
+					test.Error(t, result).Is(b)
+				}
+			},
+		},
+		{scenario: "Wrap(a,b)",
+			exec: func(t *testing.T) {
+				// ACT
+				result := Wrap(ctx, a, b)
+
+				// ASSERT
+				test.IsTrue(t, result != nil)
+				test.That(t, result.Error()).Equals("a: b")
+				if result, ok := test.IsType[ErrorWithContext](t, result); ok {
+					test.Error(t, result).Is(a)
+					test.Error(t, result).Is(b)
+				}
+			},
+		},
+		{scenario: "Wrap(nil,nil,nil)",
+			exec: func(t *testing.T) {
+				// ARRANGE ASSERT
+				defer test.ExpectPanic(ErrIllegalOperation).Assert(t)
+
+				// ACT
+				_ = Wrap(ctx, nil, nil, nil)
+			},
+		},
 	}
 	for _, tc := range testcases {
-		t.Run(tc.name, func(t *testing.T) {
-			// ACT
-			sut := Wrap(ctx, tc.args[0], tc.args[1:]...)
-
-			// ASSERT
-			switch {
-			case tc.result == nil && sut == nil:
-				return
-			case tc.result == nil && sut != nil:
-				t.Errorf("expected nil")
-			case tc.result != nil && sut == nil:
-				t.Errorf("expected error")
-			default:
-				for _, err := range tc.args {
-					if err != nil && !errors.Is(sut, err) {
-						t.Errorf("expected error to wrap: %v", err)
-					}
-				}
-				wanted := tc.result.string
-				got := sut.Error()
-				if wanted != got {
-					t.Errorf("\nwanted %#v\ngot    %#v", wanted, got)
-				}
-			}
+		t.Run(tc.scenario, func(t *testing.T) {
+			tc.exec(t)
 		})
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,6 @@ module github.com/blugnu/errorcontext
 
 go 1.20
 
-retract v0.1.0  // published with incorrect module name in go.mod
+retract v0.1.0 // published with incorrect module name in go.mod
+
+require github.com/blugnu/test v0.4.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/blugnu/test v0.4.0 h1:ZCwb8QGwmLrbfKo5EuFlvu2xRn9Puwc352zlnUhZYmw=
+github.com/blugnu/test v0.4.0/go.mod h1:bONOZa4Ep3+OFpyJ45tL157qQCK1vPAhOTN53VnMmM8=


### PR DESCRIPTION
`errorcontext.Wrap()` with 3+ arguments was equivalent to `errors.Join()` but behaved differently with 1 or 2 error arguments.  The only way to join 2 errors was to wrap the result of an explicit `errors.Join()`.

To simplify this, `errorcontext.Join()` is introduced as a direct and consistent wrapper around `errors.Join`.  `errorcontext.Wrap()` is now simplified and only handles the 1 and 2 error cases.  The signature remains unchanged, to allow for the optionality of the 2nd error; if called with 3 or more error arguments, the function will now panic with an `ErrInvalidOperation` error.